### PR TITLE
Various changes re esgfetchtables - details below.

### DIFF
--- a/esgprep/checkvocab/context.py
+++ b/esgprep/checkvocab/context.py
@@ -16,9 +16,10 @@ from tqdm import tqdm
 
 from constants import *
 from esgprep.utils.collectors import PathCollector, DatasetCollector
+from esgprep.utils.ctx_base import BaseContext
 
 
-class ProcessingContext(object):
+class ProcessingContext(BaseContext):
     """
     Encapsulates the processing context/information for main process.
 

--- a/esgprep/drs/context.py
+++ b/esgprep/drs/context.py
@@ -22,9 +22,10 @@ from esgprep.utils.collectors import Collector
 from esgprep.utils.custom_exceptions import *
 from esgprep.utils.misc import load
 from handler import DRSTree, DRSPath
+from esgprep.utils.ctx_base import BaseContext
 
 
-class ProcessingContext(object):
+class ProcessingContext(BaseContext):
     """
     Encapsulates the processing context/information for main process.
 

--- a/esgprep/esgfetchtables.py
+++ b/esgprep/esgfetchtables.py
@@ -114,11 +114,21 @@ def get_args():
         type=str,
         help=TAG_HELP)
     ref.add_argument(
-        '--branch',
-        metavar='master',
+        '--tag-regex',
+        metavar='REGEX',
         type=str,
+        help=TAG_REGEX_HELP)
+    ref.add_argument(
+        '--branch',
+        metavar='BRANCH',
         default='master',
+        type=str,
         help=BRANCH_HELP)
+    ref.add_argument(
+        '--branch-regex',
+        metavar='REGEX',
+        type=str,
+        help=BRANCH_REGEX_HELP)
     main.add_argument(
         '--include-file',
         metavar='PYTHON_REGEX',

--- a/esgprep/fetchini/context.py
+++ b/esgprep/fetchini/context.py
@@ -9,17 +9,15 @@
 
 import logging
 import os
-import re
 import sys
 
-from requests.auth import HTTPBasicAuth
 from tqdm import tqdm
 
 from constants import *
-from esgprep.utils.misc import gh_request_content
+from esgprep.utils.ctx_base import BaseContext
 
 
-class ProcessingContext(object):
+class ProcessingContext(BaseContext):
     """
     Encapsulates the processing context/information for main process.
 
@@ -49,7 +47,10 @@ class ProcessingContext(object):
         # Init output directory
         self.make_ini_dir()
         # Init the project list to retrieve
-        self.targets = self.target_projects()
+        self.targets = self.target_projects(
+            pattern = 'esg\.(.+?)\.ini',
+            url_format = self.url.format('')
+            )
         # Init progress bar
         nfiles = len(self.targets)
         if self.pbar and nfiles:
@@ -67,16 +68,6 @@ class ProcessingContext(object):
         # Default is sys.exit(0)
         if self.error:
             sys.exit(1)
-
-    def authenticate(self):
-        """
-        Builds GitHub HTTP authenticator
-
-        :returns: The HTTP authenticator
-        :rtype: *requests.auth.HTTPBasicAuth*
-
-        """
-        return HTTPBasicAuth(self.gh_user, self.gh_password) if self.gh_user and self.gh_password else None
 
     def make_ini_dir(self):
         """
@@ -98,23 +89,3 @@ class ProcessingContext(object):
                 if not os.path.isdir(self.config_dir):
                     os.makedirs(self.config_dir)
                     logging.warning('{} created'.format(self.config_dir))
-
-    def target_projects(self):
-        """
-        Gets the available projects ids from GitHub esg.*.ini files.
-        Make the intersection with the desired projects to fetch.
-
-        :returns: The target projects
-        :rtype: *list*
-
-        """
-        pattern = 'esg\.(.+?)\.ini'
-        r = gh_request_content(self.url.format(''), auth=self.auth)
-        files = [content['name'] for content in r.json()]
-        p_avail = set([re.search(pattern, x).group(1) for x in files if re.search(pattern, x)])
-        if self.projects:
-            p = set(self.projects)
-            p_avail = p_avail.intersection(p)
-            if p.difference(p_avail):
-                logging.warning("Unavailable project(s): {}".format(', '.join(p.difference(p_avail))))
-        return list(p_avail)

--- a/esgprep/fetchtables/context.py
+++ b/esgprep/fetchtables/context.py
@@ -9,17 +9,14 @@
 
 import logging
 import os
-import re
 import sys
-
-from requests.auth import HTTPBasicAuth
 
 from constants import *
 from esgprep.utils.collectors import FilterCollection
-from esgprep.utils.misc import gh_request_content
+from esgprep.utils.ctx_base import BaseContext
 
 
-class ProcessingContext(object):
+class ProcessingContext(BaseContext):
     """
     Encapsulates the processing context/information for main process.
 
@@ -71,11 +68,15 @@ class ProcessingContext(object):
             self.file_filter.add(regex='^\..*$', inclusive=False)
         self.error = None
 
+
     def __enter__(self):
         # Init GitHub authentication
         self.auth = self.authenticate()
         # Init the project list to retrieve
-        self.targets = self.target_projects()
+        self.targets = self.target_projects(
+            pattern = '(.+?)-cmor-tables',
+            url_format = GITHUB_REPOS_API
+            )
         return self
 
     def __exit__(self, *exc):
@@ -84,32 +85,3 @@ class ProcessingContext(object):
             logging.warning(self.error)
             sys.exit(1)
 
-    def authenticate(self):
-        """
-        Builds GitHub HTTP authenticator
-
-        :returns: The HTTP authenticator
-        :rtype: *requests.auth.HTTPBasicAuth*
-
-        """
-        return HTTPBasicAuth(self.gh_user, self.gh_password) if self.gh_user and self.gh_password else None
-
-    def target_projects(self):
-        """
-        Gets the available projects ids from GitHub esg.*.ini files.
-        Make the intersection with the desired projects to fetch.
-
-        :returns: The target projects
-        :rtype: *list*
-
-        """
-        pattern = '(.+?)-cmor-tables'
-        r = gh_request_content(GITHUB_REPOS_API, auth=self.auth)
-        repos = [repo['name'] for repo in r.json()]
-        p_avail = set([re.search(pattern, x).group(1) for x in repos if re.search(pattern, x)])
-        if self.projects:
-            p = set(self.projects)
-            p_avail = p_avail.intersection(p)
-            if p.difference(p_avail):
-                logging.warning("Unavailable project(s): {}".format(', '.join(p.difference(p_avail))))
-        return list(p_avail)

--- a/esgprep/fetchtables/context.py
+++ b/esgprep/fetchtables/context.py
@@ -41,12 +41,21 @@ class ProcessingContext(object):
         self.no_ref_folder = args.no_ref_folder
         self.url = GITHUB_CONTENT_API
         self.ref_url = GITHUB_REFS_API
-        if args.branch:
-            self.ref = args.branch
-            self.ref_url += '/heads'
         if args.tag:
             self.ref = args.tag
             self.ref_url += '/tags'
+        elif args.branch_regex:
+            self.regex = args.branch_regex
+            self.ref_url += '/heads'
+        elif args.tag_regex:
+            self.regex = args.tag_regex
+            self.ref_url += '/tags'
+        else:
+            # args.branch has a default value of 'master'
+            # if not set with --branch
+            self.ref = args.branch
+            self.ref_url += '/heads'
+
         self.file_filter = FilterCollection()
         if args.include_file:
             for regex in args.include_file:
@@ -60,7 +69,7 @@ class ProcessingContext(object):
         else:
             # Default exclude hidden files
             self.file_filter.add(regex='^\..*$', inclusive=False)
-        self.error = False
+        self.error = None
 
     def __enter__(self):
         # Init GitHub authentication
@@ -71,7 +80,8 @@ class ProcessingContext(object):
 
     def __exit__(self, *exc):
         # Default is sys.exit(0)
-        if self.error:
+        if self.error:         
+            logging.warning(self.error)
             sys.exit(1)
 
     def authenticate(self):

--- a/esgprep/fetchtables/main.py
+++ b/esgprep/fetchtables/main.py
@@ -10,6 +10,7 @@
 import logging
 import os
 import sys
+import re
 
 import requests
 from tqdm import tqdm
@@ -54,6 +55,84 @@ def make_outdir(tables_dir, repository, reference=None):
     return outdir
 
 
+def fetch_tables(ctx, project, repo, ref, special_cases={}):
+    """
+    Fetch all tables for a single reference (e.g. tag or branch)
+    """
+
+    # Build output directory
+    if not ctx.no_ref_folder:
+        outdir = make_outdir(ctx.tables_dir, repo, ref)
+    else:
+        outdir = make_outdir(ctx.tables_dir, repo)
+    # Set repository url
+    url = ctx.url.format(repo)
+    url += GITHUB_API_PARAMETER.format('ref', ref)
+    # Get the list of files to fetch
+    r = gh_request_content(url=url, auth=ctx.auth)
+
+    files_info = dict([(f['name'], f) for f in r.json() if ctx.file_filter(f['name'])])
+    files = files_info.keys()
+    files.sort()
+
+    # Init progress bar
+    nfiles = len(files)
+    if ctx.pbar and nfiles:
+        files = tqdm(files,
+                     desc='Fetching {} tables'.format(project),
+                     total=nfiles,
+                     bar_format='{desc}: {percentage:3.0f}% | {n_fmt}/{total_fmt} files',
+                     ncols=100,
+                     file=sys.stdout)
+    elif not nfiles:
+        logging.info('No files found on remote repository')
+    # Get the files
+
+    for f in files:
+        # Set output file full path
+        outfile = os.path.join(outdir, f)
+
+        if f in special_cases:
+            file_info = special_cases[f]
+        else:
+            file_info = files_info[f]
+
+        # Fetching True/False depending on flags and file checksum
+        sha = file_info['sha']
+        url = file_info['download_url']
+        if do_fetching(outfile, sha, ctx.keep, ctx.overwrite):
+            # Backup old file if exists
+            backup(outfile, mode=ctx.backup_mode)
+            # fetch content
+            content = requests.get(url, auth=ctx.auth).text
+            # Write new file
+            write_content(outfile, content)
+            logging.info('{} :: FETCHED (in {})'.format(url.ljust(LEN_URL), outfile))
+        else:
+            logging.info('{} :: SKIPPED'.format(url.ljust(LEN_URL)))
+
+
+def get_special_cases(ctx, repo):
+
+    """
+    Get a dictionary of (filename -> file_info) pairs to be used for 
+    named files in place of the file info from the general API call
+    done for the directory.  file_info should contain at least
+    the elements 'sha' and 'download_url'
+    """
+
+    # in fact there is one special case: 
+    # the CMIP6_CV.json file is obtained from master
+
+    f = 'CMIP6_CV.json'    
+    url = ctx.url.format(repo)
+    url += '/{}'.format(f)
+    url += GITHUB_API_PARAMETER.format('ref', 'master')
+    r = gh_request_content(url=url, auth=ctx.auth)
+
+    return { f: r.json() }
+
+
 def run(args):
     """
     Main process that:
@@ -76,56 +155,25 @@ def run(args):
                 url = ctx.ref_url.format(repo)
                 # Get the list of available refs
                 r = gh_request_content(url=url, auth=ctx.auth)
-                refs = [os.path.basename(ref['url']) for ref in r.json()]
-                if ctx.ref not in refs:
-                    raise GitHubReferenceNotFound(ctx.ref, refs)
-                # Build output directory
-                if not ctx.no_ref_folder:
-                    outdir = make_outdir(ctx.tables_dir, repo, ctx.ref)
+                all_refs = [os.path.basename(ref['url']) for ref in r.json()]
+                if hasattr(ctx, 'ref'):
+                    if ctx.ref not in all_refs:
+                        raise GitHubReferenceNotFound(ctx.ref, all_refs)
+                    fetch_refs = [ctx.ref]
                 else:
-                    outdir = make_outdir(ctx.tables_dir, repo)
-                # Set repository url
-                url = ctx.url.format(repo)
-                url += GITHUB_API_PARAMETER.format('ref', ctx.ref)
-                # Get the list of files to fetch
-                r = gh_request_content(url=url, auth=ctx.auth)
-                files = [f['name'] for f in r.json() if ctx.file_filter(f['name'])]
-                # Init progress bar
-                nfiles = len(files)
-                if ctx.pbar and nfiles:
-                    files = tqdm(files,
-                                 desc='Fetching {} tables'.format(project),
-                                 total=nfiles,
-                                 bar_format='{desc}: {percentage:3.0f}% | {n_fmt}/{total_fmt} files',
-                                 ncols=100,
-                                 file=sys.stdout)
-                elif not nfiles:
-                    logging.info('No files found on remote repository')
-                # Get the files
-                for f in files:
-                    # Set output file full path
-                    outfile = os.path.join(outdir, f)
-                    # Set full file url
-                    url = ctx.url.format(repo)
-                    url += '/{}'.format(f)
-                    # Particular case of CMIP6_CV.json file
-                    # which has to be fetched from master in any case
-                    if f == 'CMIP6_CV.json':
-                        url += GITHUB_API_PARAMETER.format('ref', 'master')
-                    else:
-                        url += GITHUB_API_PARAMETER.format('ref', ctx.ref)
-                    # Get GitHub file content
-                    r = gh_request_content(url=url, auth=ctx.auth)
-                    sha = r.json()['sha']
-                    content = requests.get(r.json()['download_url'], auth=ctx.auth).text
-                    # Fetching True/False depending on flags and file checksum
-                    if do_fetching(outfile, sha, ctx.keep, ctx.overwrite):
-                        # Backup old file if exists
-                        backup(outfile, mode=ctx.backup_mode)
-                        # Write new file
-                        write_content(outfile, content)
-                        logging.info('{} :: FETCHED (in {})'.format(url.ljust(LEN_URL), outfile))
-                    else:
-                        logging.info('{} :: SKIPPED'.format(url.ljust(LEN_URL)))
-        except GitHubException:
-            ctx.error = True
+                    fetch_refs = filter(re.compile(ctx.regex).match, all_refs)
+                    logging.info('Available refs: %s' % sorted(all_refs))
+                    logging.info('Selected refs: %s' % sorted(fetch_refs))
+                    if not fetch_refs:
+                        raise GitHubReferenceNotFound('(regex: %s)' % ctx.regex,
+                                                      all_refs)
+                for ref in fetch_refs:
+                    logging.info('Fetching ref: %s' % ref)
+                    fetch_tables(ctx, project, repo, ref,
+                                 special_cases=get_special_cases(ctx, repo))
+
+        except GitHubException as exc:
+            ctx.error = exc.msg
+
+
+

--- a/esgprep/mapfile/context.py
+++ b/esgprep/mapfile/context.py
@@ -20,9 +20,10 @@ from tqdm import tqdm
 from constants import *
 from esgprep.utils.collectors import VersionedPathCollector, DatasetCollector
 from esgprep.utils.custom_exceptions import *
+from esgprep.utils.ctx_base import BaseContext
 
 
-class ProcessingContext(object):
+class ProcessingContext(BaseContext):
     """
     Encapsulates the processing context/information for main process.
 

--- a/esgprep/utils/constants.py
+++ b/esgprep/utils/constants.py
@@ -261,7 +261,10 @@ GITHUB_USER_HELP = \
 GITHUB_PASSWORD_HELP = \
     """
     GitHub password.|n
-    Default is the GH_PASSWORD environment variable if exists.
+    Default is the GH_PASSWORD environment variable if exists.|n
+    If the username is set, but the password is not provided|n
+    as a command line option nor as an environment variable,|n
+    then it is prompted for interactively.
     
     """
 

--- a/esgprep/utils/constants.py
+++ b/esgprep/utils/constants.py
@@ -278,9 +278,21 @@ BRANCH_HELP = \
 
     """
 
+BRANCH_REGEX_HELP = \
+    """
+    Fetch from all GitHub branches matching specified regex.|n
+
+    """
+
 TAG_HELP = \
     """
     Fetch from a GitHub tag.
+
+    """
+
+TAG_REGEX_HELP = \
+    """
+    Fetch from all GitHub tags matching specified regex.|n
 
     """
 

--- a/esgprep/utils/ctx_base.py
+++ b/esgprep/utils/ctx_base.py
@@ -1,0 +1,47 @@
+import sys
+import getpass
+import re
+from requests.auth import HTTPBasicAuth
+
+from esgprep.utils.misc import gh_request_content
+
+
+class BaseContext(object):
+    """
+    base class for context, containing any methods shared by more than one operation within esgprep
+    """
+
+    def target_projects(self, pattern, url_format):
+        """
+        Gets the available projects ids from GitHub esg.*.ini files.
+        Make the intersection with the desired projects to fetch.
+
+        :returns: The target projects
+        :rtype: *list*
+        """
+
+        r = gh_request_content(url_format, auth=self.auth)
+        names = [item['name'] for item in r.json()]
+        p_avail = set([re.search(pattern, x).group(1) for x in names if re.search(pattern, x)])
+        if self.projects:
+            p = set(self.projects)
+            p_avail = p_avail.intersection(p)
+            if p.difference(p_avail):
+                logging.warning("Unavailable project(s): {}".format(', '.join(p.difference(p_avail))))
+        return list(p_avail)
+
+
+    def authenticate(self):
+        """
+        Builds GitHub HTTP authenticator
+
+        :returns: The HTTP authenticator
+        :rtype: *requests.auth.HTTPBasicAuth*
+
+        """
+        # if the username is set but not the password, prompt for it interactively
+        if self.gh_user and not self.gh_password and sys.stdout.isatty():
+            self.gh_password = getpass.getpass('Github password for user {}: '.format(self.gh_user))
+
+        return HTTPBasicAuth(self.gh_user, self.gh_password) if self.gh_user and self.gh_password else None
+


### PR DESCRIPTION
(1) Add options
    --tag-regex
and
    --branch-regex

to allow multiple tags or multiple branches to be fetched.

Example:

   esgfetchtables --project cmip6 --branch-regex '[0-9\.]+$'

(2) Store the checksum and download URL for each file from the initial API
response relating to the whole directory (not only the name), avoiding the
need for API call for file info for each file individually.  This makes it
much faster, and far fewer API calls.  There is also a single API call for
the CMIP6_CV.json file done before any looping over branches/tags, because
this is always from master.

(3) The "ctx.error" property is changed from a Boolean to a string or None,
so that the status can be properly displayed in case of an exception.