### PR TITLE
fix unwanted characters in `esgmapfile show --quiet` output (again)

### DIFF
--- a/esgprep/esgcheckvocab.py
+++ b/esgprep/esgcheckvocab.py
@@ -133,8 +133,6 @@ def main():
     # Get command-line arguments
     prog, args = get_args()
     setattr(args, 'prog', prog)
-    if not hasattr(args, 'quiet'):
-        setattr(args, 'quiet', None)
     # Run program
     run(args)
 

--- a/esgprep/esgdrs.py
+++ b/esgprep/esgdrs.py
@@ -222,8 +222,6 @@ def main():
     # Get command-line arguments
     prog, args = get_args()
     setattr(args, 'prog', prog)
-    if not hasattr(args, 'quiet'):
-        setattr(args, 'quiet', None)
     # Run program
     run(args)
 

--- a/esgprep/esgfetchini.py
+++ b/esgprep/esgfetchini.py
@@ -113,8 +113,6 @@ def main(args=None):
     # Get command-line arguments
     prog, args = get_args(args)
     setattr(args, 'prog', prog)
-    if not hasattr(args, 'quiet'):
-        setattr(args, 'quiet', None)
     # Run program
     run(args)
 

--- a/esgprep/esgfetchtables.py
+++ b/esgprep/esgfetchtables.py
@@ -147,8 +147,6 @@ def main():
     # Get command-line arguments
     prog, args = get_args()
     setattr(args, 'prog', prog)
-    if not hasattr(args, 'quiet'):
-        setattr(args, 'quiet', None)
     # Run program
     run(args)
 

--- a/esgprep/esgmapfile.py
+++ b/esgprep/esgmapfile.py
@@ -234,8 +234,6 @@ def main():
     # Get command-line arguments
     prog, args = get_args()
     setattr(args, 'prog', prog)
-    if not hasattr(args, 'quiet'):
-        setattr(args, 'quiet', None)
     # Run program
     run(args)
 

--- a/esgprep/mapfile/context.py
+++ b/esgprep/mapfile/context.py
@@ -58,7 +58,6 @@ class ProcessingContext(MultiprocessingContext):
         self.no_cleanup = args.no_cleanup
         # Mapfile path display behavior
         self.basename = args.basename if hasattr(args, 'basename') else False
-        self.quiet = args.quiet if hasattr(args, 'quiet') else False
         # Scan behavior
         self.all = args.all_versions
         if self.all:

--- a/esgprep/mapfile/main.py
+++ b/esgprep/mapfile/main.py
@@ -19,6 +19,7 @@ from esgprep.utils.custom_print import *
 from esgprep.utils.misc import evaluate, remove, get_checksum_pattern, ProcessContext
 from handler import File, Dataset
 from lockfile import LockFile
+from esgprep.utils.output_control import OutputControl
 
 
 def get_output_mapfile(outdir, attributes, mapfile_name, dataset_id, dataset_version, mapfile_drs=None, basename=False):
@@ -253,6 +254,14 @@ def run(args):
     :param ArgumentParser args: Command-line arguments parser
 
     """
+
+    # Deal with 'quiet' option separately. If set, turn off all output 
+    # before creating ProcessingContext, and turn it on only when needed
+    quiet = args.quiet if hasattr(args, 'quiet') else False
+    if quiet:
+        output_control = OutputControl()
+        output_control.stdout_off()
+
     # Instantiate processing context
     with ProcessingContext(args) as ctx:
         # Init process context
@@ -286,7 +295,13 @@ def run(args):
                 # Remove mapfile working extension
                 if ctx.action == 'show':
                     # Print mapfiles to be generated
-                    Print.result(remove(WORKING_EXTENSION, mapfile))
+                    result = remove(WORKING_EXTENSION, mapfile)
+                    if quiet:
+                        output_control.stdout_on()
+                        print result
+                        output_control.stdout_off()
+                    else:
+                        Print.result(result)
                 elif ctx.action == 'make':
                     # A final mapfile is silently overwritten if already exists
                     os.rename(mapfile, remove(WORKING_EXTENSION, mapfile))

--- a/esgprep/utils/context.py
+++ b/esgprep/utils/context.py
@@ -25,7 +25,7 @@ class BaseContext(object):
 
     def __init__(self, args):
         # Init print management
-        Print.init(log=args.log, debug=args.debug, cmd=args.prog, quiet=args.quiet)
+        Print.init(log=args.log, debug=args.debug, cmd=args.prog)
         # Print command-line
         Print.command()
         # Get project

--- a/esgprep/utils/custom_print.py
+++ b/esgprep/utils/custom_print.py
@@ -140,16 +140,14 @@ class Print(object):
     LOG = None
     DEBUG = False
     CMD = None
-    QUIET = None
     BUFFER = Value(c_char_p, '')
     LOGFILE = None
     CARRIAGE_RETURNED = True
 
     @staticmethod
-    def init(log, debug, cmd, quiet):
+    def init(log, debug, cmd):
         Print.LOG = log
         Print.DEBUG = debug
-        Print.QUIET = quiet
         Print.CMD = cmd
         logname = '{}-{}'.format(Print.CMD, datetime.now().strftime("%Y%m%d-%H%M%S"))
         if Print.LOG:
@@ -184,11 +182,10 @@ class Print(object):
     def progress(msg):
         if not Print.CARRIAGE_RETURNED:
             msg = '\n' + msg
-        if not Print.QUIET:
-            if Print.LOG:
-                Print.print_to_stdout(msg)
-            elif not Print.DEBUG:
-                Print.print_to_stdout(msg)
+        if Print.LOG:
+            Print.print_to_stdout(msg)
+        elif not Print.DEBUG:
+            Print.print_to_stdout(msg)
 
     @staticmethod
     def command(msg=None):
@@ -197,11 +194,10 @@ class Print(object):
         msg = TAGS.COMMAND + COLOR('magenta')(msg) + '\n'
         if not Print.CARRIAGE_RETURNED:
             msg = '\n' + msg
-        if not Print.QUIET:
-            if Print.LOG:
-                Print.print_to_logfile(msg)
-            elif Print.DEBUG:
-                Print.print_to_stdout(msg)
+        if Print.LOG:
+            Print.print_to_logfile(msg)
+        elif Print.DEBUG:
+            Print.print_to_stdout(msg)
 
     @staticmethod
     def log(msg=None):
@@ -218,30 +214,28 @@ class Print(object):
         msg += '\n'
         if not Print.CARRIAGE_RETURNED:
             msg = '\n' + msg
-        if not Print.QUIET:
-            if Print.LOG:
-                Print.print_to_stdout(msg)
-                Print.print_to_logfile(msg)
-            else:
-                Print.print_to_stdout(msg)
+        if Print.LOG:
+            Print.print_to_stdout(msg)
+            Print.print_to_logfile(msg)
+        else:
+            Print.print_to_stdout(msg)
 
     @staticmethod
     def info(msg):
         msg += '\n'
         if not Print.CARRIAGE_RETURNED:
             msg = '\n' + msg
-        if not Print.QUIET:
-            if Print.LOG:
-                Print.print_to_logfile(msg)
-            elif Print.DEBUG:
-                Print.print_to_stdout(msg)
+        if Print.LOG:
+            Print.print_to_logfile(msg)
+        elif Print.DEBUG:
+            Print.print_to_stdout(msg)
 
     @staticmethod
     def debug(msg):
         msg = TAGS.DEBUG + COLOR().italic(msg) + '\n'
         if not Print.CARRIAGE_RETURNED:
             msg = '\n' + msg
-        if not Print.QUIET and Print.DEBUG:
+        if Print.DEBUG:
             if Print.LOG:
                 Print.print_to_logfile(msg)
             else:
@@ -252,11 +246,10 @@ class Print(object):
         msg = TAGS.WARNING + COLOR().bold(msg) + '\n'
         if not Print.CARRIAGE_RETURNED:
             msg = '\n' + msg
-        if not Print.QUIET:
-            if Print.LOG:
-                Print.print_to_logfile(msg)
-            else:
-                Print.print_to_stdout(msg)
+        if Print.LOG:
+            Print.print_to_logfile(msg)
+        else:
+            Print.print_to_stdout(msg)
 
     @staticmethod
     def error(msg, buffer=False):

--- a/esgprep/utils/output_control.py
+++ b/esgprep/utils/output_control.py
@@ -1,0 +1,56 @@
+"""
+Class to allow switching output messages on and off.
+"""
+
+import sys
+import os
+
+class OutputControl:
+
+    def __init__(self):
+        self.null = open("/dev/null", "w")
+        self.null_fh = self.null.fileno()
+        self.stdout_fh = sys.stdout.fileno()
+        self.stdout_copy_fh = os.dup(self.stdout_fh)
+        self.stderr_fh = sys.stderr.fileno()
+        self.stderr_copy_fh = os.dup(self.stderr_fh)
+
+    def stdout_on(self):
+        sys.stdout.flush()
+        os.dup2(self.stdout_copy_fh, self.stdout_fh)
+
+    def stdout_off(self):
+        sys.stdout.flush()
+        os.dup2(self.null_fh, self.stdout_fh)
+
+    def stderr_on(self):
+        sys.stderr.flush()
+        os.dup2(self.stderr_copy_fh, self.stderr_fh)
+
+    def stderr_off(self):
+        sys.stderr.flush()
+        os.dup2(self.null_fh, self.stderr_fh)
+
+
+
+
+# test code
+if __name__ == '__main__':
+
+    oc = OutputControl()
+
+    for i in range(10):
+
+        if i % 2 == 0:
+            oc.stdout_on()
+        else:
+            oc.stdout_off()
+
+        if i % 3 == 0:
+            oc.stderr_on()
+        else:
+            oc.stderr_off()
+
+        print "stdout:", i
+        sys.stderr.write("stderr: {}\n".format(i))
+


### PR DESCRIPTION
Again, there has been some change (this time between 2.8.3 and 2.9.0), which means that the output of `esgmapfile show --quiet` contains some message other than the mapfile path. The purpose of this flag is to allow the output to be captured by a script, so it is very important that nothing else is included in the output.  There is a newline printed after the message, so simple testing in an interactive terminal does not expose the error, but if the output is piped to `od -c` then it is very obvious:

```
$ esgmapfile show --quiet --project cmip6 -i /path/to/ini_dir --outdir /path/to/out_dir --dataset-id CMIP6.HighResMIP.MOHC.HadGEM3-GC31-HM.highresSST-present.r1i1p1f1.day.ua.gn.v20180527 | od -c
0000000  \r   C   o   l   l   e   c   t   i   n   g       d   a   t   a
0000020   .   .   .       /  \r   C   o   l   l   e   c   t   i   n   g
0000040       d   a   t   a   .   .   .       -  \r 033   [   K   /   
```

(I truncated the output after what is shown above, in order not to show the real paths in public, but the remainder of the output is the path to the mapfile.)

In this case, the unwanted line in question is printed somewhere during the initialisation of `ProcessingContext`.

This is the second time that there have been such problems, and there is always a possibility that some future change will similarly add unexpected output from somewhere else in the code.  So I believe that it is time to implement `--quiet` using a more radical strategy, so that, instead of suppressing certain messages, output is disabled in general and is only enabled for the specific line of output which is wanted.

This pull request removes the existing implementation, and adds an "output control" class which adds methods which enable and disable output at the operating system level (after flushing python I/O buffers).  Then when `--quiet` is set, the output is disabled at the start of `run` and is enabled only for a simple `print` statement before being disabled again.

The "output control" class provides similar functions to control stderr, but at present these are not called (so `--quiet` does not affect stderr).  Any calling script which captures stdout can discard stderr if required.