### PR TITLE
KeyError thrown if project doesn't exist in PID_PREFIXES dictionary

### DIFF
--- a/esgprep/utils/misc.py
+++ b/esgprep/utils/misc.py
@@ -200,10 +200,11 @@ def get_tracking_id(ffp, project):
             id = f.getncattr('tracking_id')
             try:
                 prefix, uid = id.split('/')
+                assert prefix == PID_PREFIXES[project]
             except ValueError:
                 prefix = None
                 uid = id
-            assert prefix == PID_PREFIXES[project]
+                assert project not in PID_PREFIXES
             assert is_uuid(uid)
             return id
         else:


### PR DESCRIPTION
When checking the "tracking_id" attribute from a NetCDF file, if the
project doesn't exist in "PID_PREFIXES" (eg. CMIP5) then the assert
statement causes a KeyError.  If a given project doesn't use prefixes,
then presumably it shouldn't appear in the dictionary either so check
for that separately.