### PR TITLE
(untested) add an option to log to stdout

### DIFF
--- a/esgprep/utils/custom_print.py
+++ b/esgprep/utils/custom_print.py
@@ -180,6 +180,7 @@ class Print(object):
     LOG = None
     DEBUG = False
     CMD = None
+    LOG_TO_STDOUT = False
     BUFFER = Value(c_char_p, '')
     LOGFILE = None
     CARRIAGE_RETURNED = True
@@ -189,6 +190,9 @@ class Print(object):
         Print.LOG = log
         Print.DEBUG = debug
         Print.CMD = cmd
+        Print.LOG_TO_STDOUT = (log == '-')
+        if Print.LOG_TO_STDOUT:
+            return
         logname = '{}-{}'.format(Print.CMD, datetime.now().strftime("%Y%m%d-%H%M%S"))
         if Print.LOG:
             logdir = Print.LOG
@@ -208,15 +212,20 @@ class Print(object):
     @staticmethod
     def print_to_stdout(msg):
         Print.check_carriage_return(msg)
-        sys.stdout.write(msg)
-        sys.stdout.flush()
+        if not Print.LOG_TO_STDOUT:
+            sys.stdout.write(msg)
+            sys.stdout.flush()
 
     @staticmethod
     def print_to_logfile(msg):
         Print.check_carriage_return(msg)
-        with open(Print.LOGFILE, 'a+') as f:
-            msg = re.sub('\\033\[([\d];)?[\d]*m', '', msg)
-            f.write(msg)
+        msg = re.sub('\\033\[([\d];)?[\d]*m', '', msg)
+        if Print.LOG_TO_STDOUT:
+            sys.stdout.write(msg)
+            sys.stdout.flush()
+        else:
+            with open(Print.LOGFILE, 'a+') as f:
+                f.write(msg)
 
     @staticmethod
     def progress(msg):

--- a/esgprep/utils/custom_print.py
+++ b/esgprep/utils/custom_print.py
@@ -211,10 +211,11 @@ class Print(object):
 
     @staticmethod
     def print_to_stdout(msg):
+        if Print.LOG_TO_STDOUT:
+            return
         Print.check_carriage_return(msg)
-        if not Print.LOG_TO_STDOUT:
-            sys.stdout.write(msg)
-            sys.stdout.flush()
+        sys.stdout.write(msg)
+        sys.stdout.flush()
 
     @staticmethod
     def print_to_logfile(msg):

--- a/esgprep/utils/help.py
+++ b/esgprep/utils/help.py
@@ -89,6 +89,7 @@ If not set, the usual ESGF datanode directory is used (i.e., "/esg/config/esgcet
 
 LOG_HELP = """Logfile directory.
 If not, standard output is used.
+Special case, with '--log -', messages are written to standard output as they would appear in a log file, and the usual output to standard output is suppressed.
 
 """
 


### PR DESCRIPTION
This pull request would need testing before merging, but the intention is to add a `--log -` option, which causes messages to be written to standard output as they would appear in a log file, while suppressing what is usually written to standard output.

The purpose is to provide a way for the caller to have more control over the logging than can be obtained using the `--log` flag (which only permits to specify a directory, and then decides on the filename). With this option, the caller can request logging to stdout, and the caller can then redirect this to whatever file is wanted. This is _not_ the same as if `-log` is not specified at all, because the data normally written to stdout is not the same as what is written to the logfile (for example in esgmapfile it contains colours and the spinner but not the filenames).