### PR TITLE
UNTESTED: make "esgmapfile show" serial

### DIFF
--- a/esgprep/esgmapfile.py
+++ b/esgprep/esgmapfile.py
@@ -134,12 +134,6 @@ def get_args():
         type=str,
         help=DATASET_NAME_HELP)
     parent.add_argument(
-        '--max-processes',
-        metavar='4',
-        type=processes_validator,
-        default=4,
-        help=MAX_PROCESSES_HELP)
-    parent.add_argument(
         '--no-cleanup',
         action='store_true',
         default=False,
@@ -189,6 +183,12 @@ def get_args():
         metavar='CHECKSUM_FILE',
         type=FileType('r'),
         help=CHECKSUMS_FROM_HELP)
+    make.add_argument(
+        '--max-processes',
+        metavar='4',
+        type=processes_validator,
+        default=4,
+        help=MAX_PROCESSES_HELP)
     # Subparser for "esgmapfile show"
     show = subparsers.add_parser(
         'show',

--- a/esgprep/utils/context.py
+++ b/esgprep/utils/context.py
@@ -110,7 +110,13 @@ class MultiprocessingContext(BaseContext):
         if hasattr(args, 'incoming'):
             self.incoming = args.incoming
         # Multiprocessing configuration
-        self.processes = args.max_processes if args.max_processes <= cpu_count() else cpu_count()
+        if 'max_processes' in args:
+            # an operation which supports --max_processes
+            # (whether the value was specified by user, or argparse provided the default)
+            self.processes = args.max_processes if args.max_processes <= cpu_count() else cpu_count()
+        else:
+            # an operation which does not support --max_processes is defined as serial
+            self.processes = 1
         self.use_pool = (self.processes != 1)
         # Scan counters
         self.scan_errors = 0

--- a/esgprep/utils/context.py
+++ b/esgprep/utils/context.py
@@ -110,7 +110,7 @@ class MultiprocessingContext(BaseContext):
         if hasattr(args, 'incoming'):
             self.incoming = args.incoming
         # Multiprocessing configuration
-        if 'max_processes' in args:
+        if hasattr(args, 'max_processes'):
             # an operation which supports --max_processes
             # (whether the value was specified by user, or argparse provided the default)
             self.processes = args.max_processes if args.max_processes <= cpu_count() else cpu_count()


### PR DESCRIPTION
Parallelisation is not really useful for "esgmapfile show".

An untested patch to remove the `--max-processes` argument and make it run as serial.