### PR TITLE
add cftime version in requirements.txt to avoid netcdf4 install error

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
 
   run:
     - python
+    - cftime
     - lockfile
     - esgf-config-parser
     - requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-requests
-fuzzywuzzy
-netCDF4
-lockfile
-hurry.filesize
-treelib
-esgconfigparser
+lockfile==0.12.2
+cftime==1.0.3.4
+esgconfigparser==0.1.17
+requests==2.20.0
+fuzzywuzzy==0.16.0
+netCDF4==1.4.0
+hurry.filesize==0.9
+treelib==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ else:
           include_package_data=True,
           python_requires='>=2.7, <3.0',
           install_requires=['lockfile==0.12.2',
+                            'cftime==1.0.3.4'
                             'esgconfigparser==0.1.17',
                             'requests==2.20.0',
                             'fuzzywuzzy==0.16.0',


### PR DESCRIPTION
Change requirement.txt : add version ==, and add explicit cftime to avoid netcdf4 error in python 2.7 environment