### PR TITLE
do not require that uuids in tracking IDs be version 4

### DIFF
--- a/esgprep/_utils/ncfile.py
+++ b/esgprep/_utils/ncfile.py
@@ -116,7 +116,7 @@ def is_valid(identifier : str, project: str)->bool:
     return True
 
 
-def is_uuid(uuid_string, version=4):
+def is_uuid(uuid_string, version=None):
     """
     Validates an UUID.
 


### PR DESCRIPTION
This one-line commit will prevent `esgdrs` from making assumptions about what UUID version must be used in the tracking ID.  Otherwise some valid data cannot be published.

I see that both `clean` and `devel3` have had recent commits, and I am not sure which branch is relevant, so I have branched from where these two diverge from each other, so that it can be merged into either.  