### PR TITLE
fix(ci):ci python version dont test 3.14 (dependency with max 3.13, will

### DIFF
--- a/.github/workflows/test_py_version.yml
+++ b/.github/workflows/test_py_version.yml
@@ -15,7 +15,7 @@ jobs:
         python-version:
           - "3.12"
           - "3.13"
-          - "3.14"
+    #     - "3.14"
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
become 3.14 in the future)