### PR TITLE
get checksums_from working

### DIFF
--- a/esgprep/_contexts/multiprocessing.py
+++ b/esgprep/_contexts/multiprocessing.py
@@ -139,8 +139,8 @@ class MultiprocessingContext(BaseContext):
         self.checksums_from = self.set("checksums_from")
 
         # Checksums file takes priority on checksumming behavior setting.
-        if self.checksums_from:
-            self.no_checksum = True
+        if self.checksums_from and self.no_checksum:
+            self.no_checksum = False
             Print.warning('"--checksums-from" ignores "--no-checksum".')
 
         # Set multiprocessing configuration. Processes number is caped by cpu_count().

--- a/esgprep/_utils/checksum.py
+++ b/esgprep/_utils/checksum.py
@@ -297,14 +297,12 @@ def get_checksum(ffp, checksum_type="sha256", checksums=None):
     2. Through a list of checksums in a dictionary way {file: checksum}.
 
     """
-    # Verify checksum dictionary.
-    if checksums:
-        # Verify file in dictionary keys.
-        if ffp in checksums:
-            # Verify checksum pattern.
-            if re.match(get_checksum_pattern(checksum_type), checksums[ffp]):
-                # Return pre-computed checksum.
-                return checksums[ffp]
+    # If pre-computed checksum with correct pattern exists in dictionary,
+    # then return it.
+    if (checksums
+        and ffp in checksums
+        and re.match(get_checksum_pattern(checksum_type), checksums[ffp])):
+        return checksums[ffp]
 
-    # Return computed checksum.
+    # Otherwise return computed checksum.
     return checksum(ffp, checksum_type)

--- a/esgprep/esgmapfile.py
+++ b/esgprep/esgmapfile.py
@@ -199,7 +199,7 @@ def get_args():
     make.add_argument(
         "--checksums-from",
         metavar="CHECKSUM_FILE",
-        type=ChecksumsReader,
+        action=ChecksumsReader,
         help=CHECKSUMS_FROM_HELP,
     )
     make.add_argument(
@@ -234,7 +234,7 @@ def get_args():
     group.add_argument(
         "--dataset-list",
         metavar="TXT_FILE",
-        type=DatasetsReader,
+        action=DatasetsReader,
         nargs="?",
         const=sys.stdin,
         help=DATASET_LIST_HELP,


### PR DESCRIPTION
A couple of minor bugs were preventing the `--checksum-from` option in esgmapfile from working:

- a class intended to be used with `action=` in argparse was being used with `type=`  .  (PR also corrects another similar bug, not directly related to checksumming.)
- correct some wrong logic that was disabling output of checksum with `--checksums-from` was used.  We want `self.no_checksum` set to `False` so that checksums are output.  (They will only be computed for files that are not listed.)

Now tested and working.

PR also includes a minor tidyup of some nested `if` statements (replace with `and`)