### PR TITLE
add --output-depth functionality on esgmapfile

### DIFF
--- a/esgprep/_utils/help.py
+++ b/esgprep/_utils/help.py
@@ -406,7 +406,11 @@ If {dataset_id} is not present in mapfile name, then all datasets will be writte
 """
 
 OUTDIR_HELP = """Mapfile(s) output directory.
-A "mapfile_drs" can be defined per project section in INI files and joined to build a mapfiles tree.
+
+"""
+
+OUTPUT_DEPTH_HELP = """Number of subdirectories to create under mapfile output directory.
+These will be the leading components of the DRS, taken from the mapfile name.
 
 """
 

--- a/esgprep/esgmapfile.py
+++ b/esgprep/esgmapfile.py
@@ -35,6 +35,7 @@ from esgprep._utils.help import (
     NO_CHECKSUM_HELP,
     NO_CLEANUP_HELP,
     NO_COLOR_HELP,
+    OUTPUT_DEPTH_HELP,
     OUTDIR_HELP,
     PROGRAM_DESC,
     PROJECT_HELP,
@@ -177,7 +178,6 @@ def get_args():
         add_help=False,
         parents=[parent],
     )
-
     make.add_argument(
         "--directory",
         action=DirectoryChecker,
@@ -219,7 +219,10 @@ def get_args():
         default=None,
         help=RETRY_FROM_HELP,
     )
-
+    make.add_argument(
+        "--output-depth", metavar="DEPTH", type=int, default=0, help=OUTPUT_DEPTH_HELP
+    )
+    
     # Subparser for "esgmapfile show"
     show = subparsers.add_parser(
         "show",

--- a/esgprep/mapfile/context.py
+++ b/esgprep/mapfile/context.py
@@ -36,6 +36,9 @@ class ProcessingContext(MultiprocessingContext):
         # Set mapfile output directory.
         self.outdir = self.set("outdir")
 
+        # Set mapfile output subdirectory depth
+        self.output_depth = self.set("output_depth")
+
         # Enable/disable working mapfile cleanup.
         self.no_cleanup = self.set("no_cleanup", None)
 

--- a/esgprep/mapfile/make.py
+++ b/esgprep/mapfile/make.py
@@ -38,6 +38,7 @@ class Process(object):
         self.checksum_type = ctx.checksum_type
         self.notes_url = ctx.notes_url
         self.notes_title = ctx.notes_title
+        self.output_depth = ctx.output_depth
         self.progress = ctx.progress
         self.msg_length = ctx.msg_length
         self.lock = ctx.lock
@@ -109,13 +110,9 @@ class Process(object):
 
             # Build mapfile directory.
             outdir = Path(self.outdir).resolve(strict=False)
-            # try:
-            #     outdir = outdir.joinpath(self.cfg.get(section='config:{}'.format(get_project(source)),
-            #                                           option='mapfile_drs',
-            #                                           vars=get_terms(source)))
-            #
-            # except:
-            #     pass
+
+            # Add subdirectories below outdir
+            outdir = outdir.joinpath(*outfile.name.split(".")[:self.output_depth])
 
             # Build full mapfile path.
             outpath = outdir.joinpath(outfile)


### PR DESCRIPTION
Hi, @ltroussellier 

I am creating this pull request to add a feature that lets you specify a depth that is the number of DRS elements below the top-level output directory when creating mapfiles.

For example, if you have dataset ID:
```
MIP-DRS7.CMIP7.CMIP.UKNCSP.UKCM2-0-LL.piControl.r1i1p1f1.glb.mon.abs550aer.tavg-u-hxy-u.g110.v20260729
```
and you specify `--outdir <topdir> --output-depth 5` (for some value of `<topdir>`), then the mapfile is stored at
```
<topdir>/MIP-DRS7/CMIP7/CMIP/UKNCSP/UKCM2-0-LL/MIP-DRS7.CMIP7.CMIP.UKNCSP.UKCM2-0-LL.piControl.r1i1p1f1.glb.mon.abs550aer.tavg-u-hxy-u.g110.v20260729.map
```
i.e. in this example it has created 5 levels of subdirectories.

We really need this feature at CEDA in order to organise the mapfiles in a tidy way and not dump everything into a flat directory.

I originally created the branch `mapfile_output_depth`, but it has not been merged (I think I forgot to create a PR), and now the branches have diverged a bit, so I have created a separate branch `mapfile_output_depth_new` with the commit rebased onto the current `main`.

I would be grateful if you can please merge this.

Thanks.